### PR TITLE
Fix image check in cico_build_deploy.sh

### DIFF
--- a/cico_build_deploy.sh
+++ b/cico_build_deploy.sh
@@ -16,7 +16,7 @@ TEMPLATE="openshift/mattermost.app.yaml"
 
 #Find tag used by deployment template
 echo -e "Scanning OpenShift Deployment Template for Image tag"
-TAG=$(cat $TEMPLATE | grep -o -e "registry.*" | awk '{split($0,array,"/")} END{print array[3]}' | awk '{split($0,array,":")} END{print array[2]}')
+TAG=$(cat $TEMPLATE | grep -A 1 "name: IMAGE_TAG" | grep "value:" |  awk '{split($0,array,":")} END{print array[2]}')
 
 #Check if image is in the registry
 echo -e "Checking if image exists on the registry"


### PR DESCRIPTION
Earlier implementation took image tag from image URL.
Use the value for the IMAGE_TAG parameter in image check.