### PR TITLE
Fix image tag in minishift/mattermost.app.yaml

### DIFF
--- a/minishift/mattermost.app.yaml
+++ b/minishift/mattermost.app.yaml
@@ -64,7 +64,7 @@ objects:
       spec:
         containers:
         - name: mattermost
-          image: registry.centos.org/mattermost/mattermost-team:4.2
+          image: registry.centos.org/mattermost/mattermost-team:${IMAGE_TAG}
           ports:
           - containerPort: 8065
             protocol: TCP
@@ -154,4 +154,4 @@ objects:
   status: {}
 parameters:
 - name: IMAGE_TAG
-  value: latest
+  value: 4.2


### PR DESCRIPTION
Make image tag specification consistent with other deployment configs by using value of IMAGE_TAG variable instead of hardcoding it in the URL