### PR TITLE
rename parameter

### DIFF
--- a/cico_build_deploy.sh
+++ b/cico_build_deploy.sh
@@ -16,7 +16,7 @@ TEMPLATE="openshift/mattermost.app.yaml"
 
 #Find tag used by deployment template
 echo -e "Scanning OpenShift Deployment Template for Image tag"
-TAG=$(cat $TEMPLATE | grep -A 1 "name: IMAGE_TAG" | grep "value:" |  awk '{split($0,array,":")} END{print array[2]}')
+TAG=$(cat $TEMPLATE | grep -A 1 "name: IMAGE_TAG_VERSION" | grep "value:" |  awk '{split($0,array,":")} END{print array[2]}')
 
 #Check if image is in the registry
 echo -e "Checking if image exists in the registry"

--- a/openshift/mattermost.app.yaml
+++ b/openshift/mattermost.app.yaml
@@ -64,7 +64,7 @@ objects:
       spec:
         containers:
         - name: mattermost
-          image: registry.centos.org/mattermost/mattermost-team:${IMAGE_TAG}
+          image: registry.centos.org/mattermost/mattermost-team:${IMAGE_TAG_VERSION}
           ports:
           - containerPort: 8065
             protocol: TCP
@@ -185,5 +185,5 @@ objects:
     wildcardPolicy: None
   status: {}
 parameters:
-- name: IMAGE_TAG
+- name: IMAGE_TAG_VERSION
   value: "4.2"

--- a/openshift/mattermost.app.yaml
+++ b/openshift/mattermost.app.yaml
@@ -187,3 +187,4 @@ objects:
 parameters:
 - name: IMAGE_TAG_VERSION
   value: "4.2"
+- name: IMAGE_TAG


### PR DESCRIPTION
renaming the IMAGE_TAG parameter to IMAGE_TAG_VERSION
for preventing it being overruled during deployment by saasherder