### PR TITLE
upgrade Image_tag to v4.7.0

### DIFF
--- a/minishift/mattermost.app.yaml
+++ b/minishift/mattermost.app.yaml
@@ -154,4 +154,4 @@ objects:
   status: {}
 parameters:
 - name: IMAGE_TAG
-  value: "4.6"
+  value: "4.7.0"

--- a/openshift/mattermost.app.yaml
+++ b/openshift/mattermost.app.yaml
@@ -186,5 +186,5 @@ objects:
   status: {}
 parameters:
 - name: IMAGE_TAG_VERSION
-  value: "4.6"
+  value: "4.7.0"
 - name: IMAGE_TAG


### PR DESCRIPTION
this will upgrade the IMAGE_TAG version to 4.7.0

and merging this will initiate a deployment of staging instance