### PR TITLE
Bump Mattermost images to v5.3

### DIFF
--- a/minishift/mattermost.app.yaml
+++ b/minishift/mattermost.app.yaml
@@ -154,4 +154,4 @@ objects:
   status: {}
 parameters:
 - name: IMAGE_TAG
-  value: "5.2-PCP"
+  value: "5.3-PCP"

--- a/openshift/mattermost.app.yaml
+++ b/openshift/mattermost.app.yaml
@@ -202,5 +202,5 @@ objects:
   status: {}
 parameters:
 - name: IMAGE_TAG_VERSION
-  value: "5.2-PCP"
+  value: "5.3-PCP"
 - name: IMAGE_TAG


### PR DESCRIPTION
This PR sets the default image tag value to v5.3 for the minishift and openshift templates
Depends on image being available and built after : https://github.com/CentOS/container-index/pull/382